### PR TITLE
use named import of `HttpsProxyAgent` istead default import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const fetch = require("node-fetch");
-const HttpsProxyAgent = require("https-proxy-agent");
+const { HttpsProxyAgent } = require("https-proxy-agent");
 const { SocksProxyAgent } = require("socks-proxy-agent");
 const readline = require("readline");
 const WebSocket = require('ws');


### PR DESCRIPTION
fix error  `HttpsProxyAgent`
- Failed to create proxy agent: HttpsProxyAgent is not a constructor